### PR TITLE
Show phantomjs install command in getting-started

### DIFF
--- a/app/pages/working-with-lineman/getting-started.md
+++ b/app/pages/working-with-lineman/getting-started.md
@@ -12,3 +12,7 @@ ordinal: 1
    $ sudo npm install -g lineman
    ```
 3. Install [Phantom JS](http://www.phantomjs.org) and make sure it's on your _PATH_
+
+   ```bash
+   $ sudo npm install -g phantomjs
+   ```


### PR DESCRIPTION
I missed this on my first read through. Adding the command would make it stick out better.
