### PR TITLE
link to gruntjs.com instead of gruntjs.org

### DIFF
--- a/app/templates/wrapper.us
+++ b/app/templates/wrapper.us
@@ -76,7 +76,7 @@
       <div class="documentation-wrap">
         <div id="intro">
           <p>
-            <a href="http://github.com/linemanjs/lineman/">Lineman</a> is a command-line utility that is hyper-focused on helping web developers build first-class JavaScript web applications. Lineman provides a thin wrapper around a number of client-side productivity tools (primarily <a href="http://www.expressjs.com">Express</a>, <a href="http://www.gruntjs.org">Grunt</a>, and <a href="http://github.com/airportyh/testem">Testem</a>), with the goal of helping developers focus on writing awesome web apps instead of worrying about workflow configuration.
+            <a href="http://github.com/linemanjs/lineman/">Lineman</a> is a command-line utility that is hyper-focused on helping web developers build first-class JavaScript web applications. Lineman provides a thin wrapper around a number of client-side productivity tools (primarily <a href="http://www.expressjs.com">Express</a>, <a href="http://www.gruntjs.com">Grunt</a>, and <a href="http://github.com/airportyh/testem">Testem</a>), with the goal of helping developers focus on writing awesome web apps instead of worrying about workflow configuration.
           </p>
 
           <div class="featured well">


### PR DESCRIPTION
'gruntjs.org' apparently leads to the Chinese language version of Grunt's page.